### PR TITLE
Pass UITabBarItem’s accessibilityIdentifier and accessibilityLabel to ESTabBarItemContainer

### DIFF
--- a/Sources/ESTabBar.swift
+++ b/Sources/ESTabBar.swift
@@ -397,7 +397,7 @@ internal extension ESTabBar /* Actions */ {
             var accessibilityTitle = ""
             
             if let item = item as? ESTabBarItem {
-                accessibilityTitle = item.title ?? ""
+                accessibilityTitle = item.accessibilityLabel ?? item.title ?? ""
             }
             if self.isMoreItem(idx) {
                 accessibilityTitle = NSLocalizedString("More_TabBarItem", bundle: Bundle(for:ESTabBarController.self), comment: "")
@@ -406,6 +406,7 @@ internal extension ESTabBar /* Actions */ {
             let formatString = NSLocalizedString(item == selectedItem ? "TabBarItem_Selected_AccessibilityLabel" : "TabBarItem_AccessibilityLabel",
                                                  bundle: Bundle(for: ESTabBarController.self),
                                                  comment: "")
+            container.accessibilityIdentifier = item.accessibilityIdentifier
             container.accessibilityLabel = String(format: formatString, accessibilityTitle, idx + 1, tabBarItems.count)
             
         }


### PR DESCRIPTION
@rami-ihr I couldn't test with voice-over yet since I am not on a device but I verified the accessibilityIdentifiers and accessibilityLabels are coming through from the tab bar item to the container. I will test with @dem0n0cracy tomorrow to verify voice-over and Appium works.